### PR TITLE
Run script check for provided arguments.

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-./gradlew run --args="$*"
-
+# Test if an argument is provided and run ./gradlew accordinly.
+if [ $# -eq 0 ]
+  then
+    ./gradlew run
+  else
+    ./gradlew run --args="$*"
+fi


### PR DESCRIPTION
Run script now checks if at least one argument is provided and execute gradlew accordingly.